### PR TITLE
added custom malloc implementation

### DIFF
--- a/tcl.c
+++ b/tcl.c
@@ -27,7 +27,7 @@ void *smalloc( size_t size)
   if ( size>MAX_STRING_LENGTH )
   {
     puts( "MALLOC ERROR: too big length" );
-    return ( void* )NULL;
+    return NULL;
   }
   uint8_t buf_verifier=0;
   while( buf_verifier<MAX_AMOUNT_OF_STRINGTH )
@@ -40,14 +40,14 @@ void *smalloc( size_t size)
     buf_verifier++;
   }
   puts( "MALLOC ERROR: no memory left" );
-  return ( void* )NULL;
+  return NULL;
 }
 void *srealloc( void*ptr, size_t size )
 {
   if ( size>MAX_STRING_LENGTH )
   {
     puts( "REALLOC ERROR: too big length" );
-    return ( void* )NULL;
+    return NULL;
   }
   if(ptr==NULL)
     return smalloc (size) ;
@@ -59,7 +59,7 @@ void *srealloc( void*ptr, size_t size )
     str_num++;
   }
   puts( "REALLOC ERROR" );
-  return ( void* )NULL;
+  return NULL;
 }
 void sfree( void* ptr )
 {

--- a/tcl_test.c
+++ b/tcl_test.c
@@ -19,6 +19,7 @@ int status = 0;
 #include "tcl_test_math.h"
 
 int main() {
+  smalloc_init();
   test_lexer();
   test_subst();
   test_flow();


### PR DESCRIPTION
I would like to use your partcl in my embedded projects so I have written malloc for this program in order to remove more dependencies and run it on bare metal. But I found out that your program  does not always use free() correctly. Sometimes it does not use correct pointer to allocated memory when uses "subst". Furthermore I could not find where your fault really is. My implementation of free() named  "sfree()"  prints "free called" when it is really called and prints "FREE ERROR", when it cannot recognize what is the pointer it received. Just type "make|less" to see this. Maybe you can find this mistake? 
There is also another problem: partcl does not verify if malloc returns NULL pointer. Maybe it is a good idea to run "exit(1);" from custom malloc/realloc instead of returning NULL.