### PR TITLE
Fixing mem issue in test, fixing unbalanced bracket/brace issue

### DIFF
--- a/tcl.c
+++ b/tcl.c
@@ -81,6 +81,9 @@ int tcl_next(const char *s, size_t n, const char **from, const char **to,
     }
     *from = *to = s + 1;
     return TWORD;
+  } else if (*s == ']' || *s == '}') {
+    /* Unbalanced bracket or brace */
+    return TERROR;
   } else {
     while (i < n && (*q || !tcl_is_space(s[i])) && !tcl_is_special(s[i], *q)) {
       i++;

--- a/tcl_test_lexer.h
+++ b/tcl_test_lexer.h
@@ -63,6 +63,10 @@ static void test_lexer() {
   check_tokens("foo bar", 3, TWORD, "foo", TWORD, "bar", TCMD, "");
   check_tokens("foo bar baz", 4, TWORD, "foo", TWORD, "bar", TWORD, "baz", TCMD,
                "");
+  /* Imbalanced braces/brackets */
+  check_tokens("foo ]", 2, TWORD, "foo", TERROR, "");
+  check_tokens("foo }", 2, TWORD, "foo", TERROR, "");
+
   /* Grouping */
   check_tokens("foo {bar baz}", 3, TWORD, "foo", TWORD, "{bar baz}", TCMD, "");
   check_tokens("foo {bar {baz} {q u x}}", 3, TWORD, "foo", TWORD,

--- a/tcl_test_subst.h
+++ b/tcl_test_subst.h
@@ -3,8 +3,8 @@
 
 static void check_eval(struct tcl *tcl, const char *s, char *expected) {
   int destroy = 0;
+  struct tcl tmp;
   if (tcl == NULL) {
-    struct tcl tmp;
     tcl_init(&tmp);
     tcl = &tmp;
     destroy = 1;


### PR DESCRIPTION
Moving struct declaration in test to outer scope. Otherwise, it is used after going out of scope causing corruption of the stack.

Adding check for a closing `]` or `}` without a matching opening one. This issue caused the REPL to hang or (new) tests to segfault.