### PR TITLE
fix memory issue: free `cmd->arg` in `tcl_destroy` only when the cmd is `tcl_user_proc`

### DIFF
--- a/tcl.c
+++ b/tcl.c
@@ -587,7 +587,6 @@ void tcl_destroy(struct tcl* tcl) {
     struct tcl_cmd* cmd = tcl->cmds;
     tcl->cmds = tcl->cmds->next;
     tcl_free(cmd->name);
-    free(cmd->arg);
     free(cmd);
   }
   tcl_free(tcl->result);

--- a/tcl.c
+++ b/tcl.c
@@ -587,6 +587,7 @@ void tcl_destroy(struct tcl* tcl) {
     struct tcl_cmd* cmd = tcl->cmds;
     tcl->cmds = tcl->cmds->next;
     tcl_free(cmd->name);
+    if (cmd->fn == tcl_user_proc && cmd->arg) { tcl_free((tcl_value_t*)cmd->arg); }
     free(cmd);
   }
   tcl_free(tcl->result);


### PR DESCRIPTION
The data of `cmd->arg` pointer is meant to be managed externally, so freeing it in `tcl_destroy` may cause unwanted results

fixes #18 